### PR TITLE
Revert "[PREVENT] Fatal error: Call to a member function lang()"

### DIFF
--- a/oxpus/basicstats/controller/main.php
+++ b/oxpus/basicstats/controller/main.php
@@ -615,7 +615,7 @@ class main
 
 		if ($options)
 		{
-			$return_str = '<fieldset><label for="' . $select_identifier . '">' . $label_prompt . ($this->user->lang['COLON']) . ' </label><select name=' . $select_identifier . ' id="' . $select_identifier . '">' . $temp_str . '</select> <input class="button2" type="submit" value="' . $submit_prompt . '" /></fieldset>';
+			$return_str = '<fieldset><label for="' . $select_identifier . '">' . $label_prompt . $this->language->lang('COLON') . ' </label><select name=' . $select_identifier . ' id="' . $select_identifier . '">' . $temp_str . '</select> <input class="button2" type="submit" value="' . $submit_prompt . '" /></fieldset>';
 		}
 
 		return $return_str;


### PR DESCRIPTION
Reverts oxpus/Basis-Statistics-32#3

On phpBB 3.2.x the object "language" should be used.